### PR TITLE
✨[FEAT]: 컨텐츠 리뷰 API 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,8 +56,8 @@
       "devDependencies": {
         "@babel/core": "^7.26.0",
         "@babel/preset-env": "^7.26.0",
-        "@types/passport-kakao": "^1.0.3",
         "@types/jest": "^29.5.14",
+        "@types/passport-kakao": "^1.0.3",
         "babel-loader": "^9.2.1",
         "copy-webpack-plugin": "^12.0.2",
         "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
   "devDependencies": {
     "@babel/core": "^7.26.0",
     "@babel/preset-env": "^7.26.0",
-    "@types/passport-kakao": "^1.0.3",
     "@types/jest": "^29.5.14",
+    "@types/passport-kakao": "^1.0.3",
     "babel-loader": "^9.2.1",
     "copy-webpack-plugin": "^12.0.2",
     "cross-env": "^7.0.3",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,7 +30,6 @@ model Summary {
   comment          comment[]
   highlight        highlight[]
   likeDislike      likeDislike[]
-  review           review[]
 
   @@index([content_id], map: "content_id_idx")
   @@index([user_id], map: "user_id_idx")
@@ -76,6 +75,8 @@ model content {
   content_genre String               @db.VarChar(255)
   content_plot  String               @db.Text
   created_at    DateTime             @default(now()) @db.DateTime(0)
+  review        review[]
+
 }
 
 model highlight {
@@ -111,10 +112,9 @@ model review {
   review_id   Int      @id @default(autoincrement())
   review_text String   @db.VarChar(255)
   created_at  DateTime @default(now()) @db.DateTime(0)
-  summary_id  Int
-  summary     Summary  @relation(fields: [summary_id], references: [summary_id], onDelete: Cascade, onUpdate: NoAction, map: "fk_review_summary_id")
-
-  @@index([summary_id], map: "fk_summary_id_idx")
+  updated_at  DateTime @default(now()) @updatedAt @db.DateTime(0)
+  content_id  Int
+  content     content  @relation(fields: [content_id], references: [content_id], onDelete: Cascade, onUpdate: NoAction, map: "fk_review_content_id")
 }
 
 enum content_content_type {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,10 @@ import { PrismaModule } from '../prisma/prisma.module';
 import { ConfigModule } from '@nestjs/config';
 import { ContentController } from 'layer/controllers/content.controller';
 import { ContentService } from 'layer/services/content.service';
+import { ReviewService } from './layer/services/review.service';
+import { ReviewController } from './layer/controllers/review.controller';
+import { ReviewModule } from './layer/modules/review.module';
+import { ReviewRepository } from './layer/repositories/review.repository';
 
 @Module({
   imports: [
@@ -14,8 +18,9 @@ import { ContentService } from 'layer/services/content.service';
     }),
     PrismaModule,
     AuthModule, 
+    ReviewModule,
   ],
-  controllers: [AppController, ContentController],
-  providers: [AppService, ContentService],
+  controllers: [AppController, ContentController, ReviewController],
+  providers: [AppService, ContentService, ReviewService, ReviewRepository],
 })
 export class AppModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -121,10 +121,10 @@ export class AuthService {
     });
   
     const mailOptions = {
-      from: this.configService.get<string>('EMAIL_USER'),
+      from: `요약러리 <${this.configService.get<string>('EMAIL_USER')}>`, // 보내는 사람 이름 설정
       to: user_email,
-      subject: '이메일 인증 코드',
-      text: `인증 코드: ${verificationCode}`,
+      subject: '요약러리 이메일 인증 코드',
+      html: `<p>요약러리의 이메일 인증 코드는 <strong style="font-size: 18px;">${verificationCode}</strong> 입니다.</p>`,
     };
   
     try {

--- a/src/layer/controllers/review.controller.ts
+++ b/src/layer/controllers/review.controller.ts
@@ -1,0 +1,47 @@
+import { Controller, Post, Get, Patch, Delete, Body, Param, ParseIntPipe } from '@nestjs/common';
+import { ReviewService } from '../services/review.service';
+import { CreateReviewDto, UpdateReviewDto } from '../dtos/review.dto';
+import { ResponseDto } from '../dtos/response.dto';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+@Controller('reviews')
+export class ReviewController {
+  constructor(private readonly reviewService: ReviewService) {}
+
+  @Post()
+  @ApiOperation({ summary: '리뷰 생성', description: '컨텐츠에 대한 리뷰를 생성합니다.' })
+  @ApiResponse({ status: 201, description: '리뷰 생성 성공' })
+  @ApiResponse({ status: 400, description: '잘못된 요청' })
+  async createReview(@Body() createReviewDto: CreateReviewDto) {
+    const result = await this.reviewService.createReview(createReviewDto);
+    return new ResponseDto(201, '리뷰 생성 성공', result);
+  }
+
+  @Get(':content_id')
+  @ApiOperation({ summary: '컨텐츠 리뷰 조회', description: '특정 컨텐츠에 대한 리뷰 목록을 조회합니다.' })
+  @ApiResponse({ status: 200, description: '리뷰 조회 성공' })
+  async getReviews(@Param('content_id', ParseIntPipe) content_id: number) {
+    const result = await this.reviewService.getReviewsByContent(content_id);
+    return new ResponseDto(200, '리뷰 조회 성공', result);
+  }
+
+  @Patch(':review_id')
+  @ApiOperation({ summary: '리뷰 수정', description: '특정 리뷰를 수정합니다.' })
+  @ApiResponse({ status: 200, description: '리뷰 수정 성공' })
+  @ApiResponse({ status: 400, description: '잘못된 요청' })
+  async updateReview(
+    @Param('review_id', ParseIntPipe) review_id: number,
+    @Body() updateReviewDto: UpdateReviewDto,
+  ) {
+    const result = await this.reviewService.updateReview(review_id, updateReviewDto);
+    return new ResponseDto(200, '리뷰 수정 성공', result);
+  }
+
+  @Delete(':review_id')
+  @ApiOperation({ summary: '리뷰 삭제', description: '특정 리뷰를 삭제합니다.' })
+  @ApiResponse({ status: 200, description: '리뷰 삭제 성공' })
+  async deleteReview(@Param('review_id', ParseIntPipe) review_id: number) {
+    await this.reviewService.deleteReview(review_id);
+    return new ResponseDto(200, '리뷰 삭제 성공', null);
+  }
+}

--- a/src/layer/dtos/content.dto.ts
+++ b/src/layer/dtos/content.dto.ts
@@ -15,6 +15,7 @@ export class CreateContentDto {
     content_genre!: string;
     content_plot!: string;
     created_at!: Date;
+    review_id!: number;
   }
   /* 스웨거에서 자동으로 스키마 인식하도록 하려면 필요하다고 합니다.
 

--- a/src/layer/dtos/review.dto.ts
+++ b/src/layer/dtos/review.dto.ts
@@ -1,19 +1,22 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsString, IsNotEmpty, IsOptional } from 'class-validator';
 
 export class CreateReviewDto {
   @ApiProperty({ example: 1, description: '연관된 컨텐츠 ID' })
+  @IsInt({ message: 'content_id는 정수여야 합니다.' })
   readonly content_id!: number;
 
   @ApiProperty({ example: '이 영화 정말 감동적이었어요!', description: '리뷰 내용' })
+  @IsString({ message: 'review_text는 문자열이어야 합니다.' })
+  @IsNotEmpty({ message: 'review_text는 비워둘 수 없습니다.' })
   readonly review_text!: string;
 }
 
 export class UpdateReviewDto {
   @ApiProperty({ example: '업데이트된 리뷰 내용', description: '변경할 리뷰 텍스트', required: false })
-  readonly review_text?: string;
-
-  @ApiProperty({ example: new Date().toISOString(), description: '수정된 날짜', required: true })
-  updated_at!: Date;
+  @IsString({ message: 'review_text는 문자열이어야 합니다.' })
+  @IsOptional()
+  review_text?: string;
 }
 
 export class ReviewResponseDto {
@@ -28,4 +31,7 @@ export class ReviewResponseDto {
 
   @ApiProperty({ example: new Date().toISOString(), description: '리뷰 생성 날짜' })
   created_at!: Date;
+
+  @ApiProperty({ example: new Date().toISOString(), description: '리뷰 수정 날짜' })
+  updated_at!: Date;
 }

--- a/src/layer/dtos/review.dto.ts
+++ b/src/layer/dtos/review.dto.ts
@@ -1,12 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class CreateReviewDto {
-    readonly review_text!: string;
-    readonly summary_id!: number;
-  }
-  
-  export class ReviewResponseDto {
-    review_id!: number;
-    review_text!: string;
-    created_at!: Date;
-    summary_id!: number;
-  }
-  
+  @ApiProperty({ example: 1, description: '연관된 컨텐츠 ID' })
+  readonly content_id!: number;
+
+  @ApiProperty({ example: '이 영화 정말 감동적이었어요!', description: '리뷰 내용' })
+  readonly review_text!: string;
+}
+
+export class UpdateReviewDto {
+  @ApiProperty({ example: '업데이트된 리뷰 내용', description: '변경할 리뷰 텍스트', required: false })
+  readonly review_text?: string;
+
+  @ApiProperty({ example: new Date().toISOString(), description: '수정된 날짜', required: true })
+  updated_at!: Date;
+}
+
+export class ReviewResponseDto {
+  @ApiProperty({ example: 1, description: '리뷰 ID' })
+  review_id!: number;
+
+  @ApiProperty({ example: 1, description: '연관된 컨텐츠 ID' })
+  content_id!: number;
+
+  @ApiProperty({ example: '이 영화 정말 감동적이었어요!', description: '리뷰 내용' })
+  review_text!: string;
+
+  @ApiProperty({ example: new Date().toISOString(), description: '리뷰 생성 날짜' })
+  created_at!: Date;
+}

--- a/src/layer/entities/content.entity.ts
+++ b/src/layer/entities/content.entity.ts
@@ -1,4 +1,5 @@
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, OneToMany } from 'typeorm';
+import { Review } from './review.entity';
 
 export enum ContentType {
   BOOK = 'book',
@@ -12,17 +13,20 @@ export class Content {
   content_id!: number;
 
   @Column({ type: 'varchar', length: 255 })
-  content_title!: string; 
+  content_title!: string;
 
   @Column({ type: 'enum', enum: ContentType })
-  content_type!: ContentType; 
+  content_type!: ContentType;
 
   @Column({ type: 'varchar', length: 255 })
-  content_genre!: string; 
+  content_genre!: string;
 
   @Column({ type: 'text' })
-  content_plot!: string; 
+  content_plot!: string;
 
-  @Column({ type: 'datetime' })
-  created_at!: Date; 
+  @CreateDateColumn()
+  created_at!: Date;
+
+  @OneToMany(() => Review, (review) => review.content, { cascade: true })
+  reviews!: Review[];
 }

--- a/src/layer/entities/review.entity.ts
+++ b/src/layer/entities/review.entity.ts
@@ -1,5 +1,5 @@
-import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, ManyToOne, JoinColumn } from 'typeorm';
-import { Summary } from './summary.entity';
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, ManyToOne, JoinColumn } from 'typeorm';
+import { Content } from './content.entity';
 
 @Entity('review')
 export class Review {
@@ -12,7 +12,10 @@ export class Review {
   @CreateDateColumn()
   created_at!: Date;
 
-  @ManyToOne(() => Summary, (summary) => summary.reviews, { onDelete: 'CASCADE' })
-  @JoinColumn({ name: 'summary_id' })
-  summary!: Summary;
+  @UpdateDateColumn()
+  updated_at!: Date;
+
+  @ManyToOne(() => Content, (content) => content.reviews, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'content_id' })
+  content!: Content;
 }

--- a/src/layer/entities/summary.entity.ts
+++ b/src/layer/entities/summary.entity.ts
@@ -3,7 +3,6 @@ import { Content } from './content.entity';
 import { User } from './user.entity';  
 import { Highlight } from './highlight.entity';
 import { LikeDislike } from './likeDislike.entity';
-import { Review } from './review.entity';
 import { Comment } from './comment.entity';
 
 @Entity('summary')
@@ -39,9 +38,6 @@ export class Summary {
 
   @OneToMany(() => LikeDislike, (likeDislike) => likeDislike.summary, { cascade: true })
 likeDislikes!: LikeDislike[];
-
-@OneToMany(() => Review, (review) => review.summary)
-reviews!: Review[];
 
 @OneToMany(() => Comment, (comment) => comment.summary)
 comments!: Comment[];

--- a/src/layer/modules/review.module.ts
+++ b/src/layer/modules/review.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ReviewService } from '../services/review.service';
+import { ReviewRepository } from '../repositories/review.repository';
+import { PrismaService } from '../../../prisma/prisma.service'; 
+
+@Module({
+    providers: [ReviewService, ReviewRepository, PrismaService], 
+  })
+  export class ReviewModule {}

--- a/src/layer/repositories/review.repository.ts
+++ b/src/layer/repositories/review.repository.ts
@@ -1,0 +1,45 @@
+// review.repository.ts
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { CreateReviewDto, UpdateReviewDto } from '../dtos/review.dto';
+
+@Injectable()
+export class ReviewRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  // 리뷰 생성
+  async create(createReviewDto: CreateReviewDto) {
+    return this.prisma.review.create({
+      data: createReviewDto,
+    });
+  }
+
+  // 특정 콘텐츠의 리뷰 찾기
+  async findByContent(content_id: number) {
+    return this.prisma.review.findMany({
+      where: { content_id },
+    });
+  }
+
+  // 특정 리뷰 찾기
+  async findOne(review_id: number) {
+    return this.prisma.review.findUnique({
+      where: { review_id },
+    });
+  }
+
+  // 리뷰 업데이트
+  async update(review_id: number, updateReviewDto: UpdateReviewDto) {
+    return this.prisma.review.update({
+      where: { review_id },
+      data: updateReviewDto,
+    });
+  }
+
+  // 리뷰 삭제
+  async delete(review_id: number) {
+    return this.prisma.review.delete({
+      where: { review_id },
+    });
+  }
+}

--- a/src/layer/services/review.service.ts
+++ b/src/layer/services/review.service.ts
@@ -1,0 +1,36 @@
+// review.service.ts
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { CreateReviewDto, UpdateReviewDto } from '../dtos/review.dto';
+import { ReviewRepository } from '../repositories/review.repository';
+
+@Injectable()
+export class ReviewService {
+  constructor(private readonly reviewRepository: ReviewRepository) {}
+
+  // 리뷰 생성
+  async createReview(createReviewDto: CreateReviewDto) {
+    return await this.reviewRepository.create(createReviewDto);
+  }
+
+  // 특정 콘텐츠의 리뷰 가져오기
+  async getReviewsByContent(content_id: number) {
+    return await this.reviewRepository.findByContent(content_id);
+  }
+
+  // 리뷰 수정
+  async updateReview(review_id: number, updateReviewDto: UpdateReviewDto) {
+    const review = await this.reviewRepository.findOne(review_id);
+    if (!review) throw new NotFoundException('리뷰를 찾을 수 없습니다.');
+
+    return await this.reviewRepository.update(review_id, updateReviewDto);
+  }
+
+  // 리뷰 삭제
+  async deleteReview(review_id: number) {
+    const review = await this.reviewRepository.findOne(review_id);
+    if (!review) throw new NotFoundException('리뷰를 찾을 수 없습니다.');
+
+    await this.reviewRepository.delete(review_id);
+    return { message: '리뷰가 삭제되었습니다.' };
+  }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[V] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[V] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
review-api -> dev

### 변경 사항
1. DB수정
  - Review테이블에 FK였던 summary_id 삭제
  - Review테이블에 updated_at 추가
  - Content테이블에 review_id를 FK로 추가
2. 컨텐츠 리뷰 기능 구현
3. 피드백 반영
  - Review.dto 요청 부분에 유효성 검사를 위한 데코레이터 추가
  - UpdateReviewDto에서 updated_at을 ReviewResponseDto로 분리
  - UpdateReviewDto에서 review_text의 readonly 제거

### 테스트 결과
- 데이터베이스 상에서 입력된 content 데이터가 없어 아직 리뷰작성 불가
