### PR TITLE
♻️ [Refactor]: 댓글 API 전체 리팩토링 및 Swagger 예시값 개선

### DIFF
--- a/src/layer/controllers/comment.controller.ts
+++ b/src/layer/controllers/comment.controller.ts
@@ -6,100 +6,201 @@ import {
   Param,
   Get,
   Delete,
-  Req,
   UseGuards,
 } from '@nestjs/common';
-import { CommentService } from '../services/comment.service';
-import { CreateCommentDto, UpdateCommentDto } from '../dtos/comment.dto';
-import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBearerAuth,
+  ApiResponse,
+} from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
+
+import { CommentService } from '../services/comment.service';
+import {
+  CreateCommentDto,
+  UpdateCommentDto,
+} from '../dtos/comment.dto';
 import { ResponseDto } from '../dtos/response.dto';
+import { CurrentUser } from '../strategies/current-user.decorator';
 
 @ApiTags('Comments')
 @ApiBearerAuth('access-token')
+@UseGuards(AuthGuard('jwt'))
 @Controller('summaries/:summary_id/comments')
 export class CommentController {
   constructor(private readonly commentService: CommentService) {}
 
-  @UseGuards(AuthGuard('jwt'))
   @Post()
   @ApiOperation({ summary: '댓글 생성' })
-  @ApiResponse({ status: 201, description: '댓글 생성 성공', type: Object })
-  async createComment(
+  @ApiResponse({
+    status: 201,
+    description: '댓글 생성 성공',
+    schema: {
+      example: {
+        status: 201,
+        message: '댓글 생성 성공',
+        data: {
+          comment_id: 14,
+          comment_parent_id: null,
+          comment_text: '정말 유익한 요약이네요!',
+          created_at: '2025-08-07T19:48:14.000Z',
+          updated_at: '2025-08-07T19:48:14.000Z',
+          summary_id: 1,
+          user_id: 9,
+          user: {
+            user_nick: 'yoyakswuni',
+          },
+          replies: [],
+        },
+      },
+    },
+  })
+  async create(
     @Param('summary_id') summaryId: string,
     @Body() dto: CreateCommentDto,
-    @Req() req,
+    @CurrentUser() user: { user_id: number },
   ) {
-    console.log('댓글 생성 요청:', {
-      summaryId,
-      userId: req.user.user_id,
-      body: dto,
-    });
-
-    const comment = await this.commentService.createComment(
+    const comment = await this.commentService.create(
       Number(summaryId),
       dto,
-      req.user.user_id,
+      user.user_id,
     );
     return new ResponseDto(201, '댓글 생성 성공', comment);
   }
 
-  @UseGuards(AuthGuard('jwt'))
   @Patch(':comment_id')
   @ApiOperation({ summary: '댓글 수정' })
-  @ApiResponse({ status: 200, description: '댓글 수정 성공', type: Object })
-  async updateComment(
+  @ApiResponse({
+    status: 200,
+    description: '댓글 수정 성공',
+    schema: {
+      example: {
+        status: 200,
+        message: '댓글 수정 성공',
+        data: {
+          comment_id: 1,
+          comment_text: '수정된 댓글입니다.',
+          comment_parent_id: null,
+          user_id: 9,
+          summary_id: 1,
+          created_at: '2025-08-07T18:17:06.000Z',
+          updated_at: '2025-08-08T02:00:00.000Z',
+          user: {
+            user_nick: 'yoyakswuni',
+          },
+          replies: [],
+        },
+      },
+    },
+  })
+  async update(
     @Param('summary_id') summaryId: string,
     @Param('comment_id') commentId: string,
     @Body() dto: UpdateCommentDto,
-    @Req() req,
+    @CurrentUser() user: { user_id: number },
   ) {
-    console.log('댓글 수정 요청:', {
-      summaryId,
-      commentId,
-      userId: req.user.user_id,
-      body: dto,
-    });
-
-    const updatedComment = await this.commentService.updateComment(
+    const updatedComment = await this.commentService.update(
       Number(summaryId),
       Number(commentId),
       dto,
-      req.user.user_id,
+      user.user_id,
     );
     return new ResponseDto(200, '댓글 수정 성공', updatedComment);
   }
 
-  @UseGuards(AuthGuard('jwt'))
   @Delete(':comment_id')
   @ApiOperation({ summary: '댓글 삭제' })
-  @ApiResponse({ status: 200, description: '댓글 삭제 성공', type: Object })
-  async deleteComment(
+  @ApiResponse({
+    status: 200,
+    description: '댓글 삭제 성공',
+    schema: {
+      example: {
+        status: 200,
+        message: '댓글 삭제 성공',
+        data: null,
+      },
+    },
+  })
+  async delete(
     @Param('summary_id') summaryId: string,
     @Param('comment_id') commentId: string,
-    @Req() req,
+    @CurrentUser() user: { user_id: number },
   ) {
-    console.log('댓글 삭제 요청:', {
-      summaryId,
-      commentId,
-      userId: req.user.user_id,
-    });
-
-    await this.commentService.deleteComment(
+    await this.commentService.delete(
       Number(summaryId),
       Number(commentId),
-      req.user.user_id,
+      user.user_id,
     );
     return new ResponseDto(200, '댓글 삭제 성공');
   }
 
   @Get()
   @ApiOperation({ summary: 'Summary에 대한 모든 댓글 조회' })
-  @ApiResponse({ status: 200, description: '댓글 목록 조회 성공', type: [Object] })
-  async getCommentsBySummary(@Param('summary_id') summaryId: string) {
-    console.log('댓글 목록 조회 요청:', { summaryId });
-
-    const comments = await this.commentService.getCommentsBySummary(Number(summaryId));
+  @ApiResponse({
+    status: 200,
+    description: '댓글 목록 조회 성공',
+    schema: {
+      example: {
+        status: 200,
+        message: '댓글 목록 조회 성공',
+        data: [
+          {
+            comment_id: 1,
+            comment_parent_id: null,
+            comment_text: '삭제된 댓글입니다.',
+            created_at: '2025-08-07T18:17:06.000Z',
+            updated_at: '2025-08-07T18:17:06.000Z',
+            summary_id: 1,
+            user_id: 9,
+            replies: [
+              {
+                comment_id: 4,
+                comment_parent_id: 1,
+                comment_text: '잘봤습니다!',
+                created_at: '2025-08-07T19:04:43.000Z',
+                updated_at: '2025-08-07T19:04:43.000Z',
+                summary_id: 1,
+                user_id: 9,
+                user: {
+                  user_nick: 'yoyakswuni',
+                },
+              },
+              {
+                comment_id: 5,
+                comment_parent_id: 1,
+                comment_text: '좋아요!',
+                created_at: '2025-08-07T19:30:48.000Z',
+                updated_at: '2025-08-07T19:30:48.000Z',
+                summary_id: 1,
+                user_id: 9,
+                user: {
+                  user_nick: 'yoyakswuni',
+                },
+              },
+              {
+                comment_id: 6,
+                comment_parent_id: 1,
+                comment_text: '수정된 댓글입니다.',
+                created_at: '2025-08-07T19:33:27.000Z',
+                updated_at: '2025-08-07T19:33:27.000Z',
+                summary_id: 1,
+                user_id: 9,
+                user: {
+                  user_nick: 'yoyakswuni',
+                },
+              },
+            ],
+            user: {
+              user_nick: 'yoyakswuni',
+            },
+          },
+        ],
+      },
+    },
+  })
+  async findBySummary(@Param('summary_id') summaryId: string) {
+    const comments = await this.commentService.findBySummary(Number(summaryId));
     return new ResponseDto(200, '댓글 목록 조회 성공', comments);
   }
 }

--- a/src/layer/converter/comment.converter.ts
+++ b/src/layer/converter/comment.converter.ts
@@ -1,0 +1,20 @@
+// src/converters/comment.converter.ts
+import { CommentResponseDto } from '../dtos/comment.dto';
+
+export class CommentConverter {
+  static toDto(entity: any): CommentResponseDto {
+    const dto = new CommentResponseDto();
+    dto.comment_id = entity.comment_id;
+    dto.comment_text = entity.comment_text;
+    dto.comment_parent_id = entity.comment_parent_id;
+    dto.summary_id = entity.summary_id;
+    dto.user_id = entity.user_id;
+    dto.created_at = entity.created_at;
+    dto.updated_at = entity.updated_at;
+    return dto;
+  }
+
+  static toDtoList(entities: any[]): CommentResponseDto[] {
+    return entities.map(this.toDto);
+  }
+}

--- a/src/layer/dtos/comment.dto.ts
+++ b/src/layer/dtos/comment.dto.ts
@@ -1,33 +1,106 @@
-import { ApiProperty } from '@nestjs/swagger';
+import {
+  ApiProperty,
+  ApiPropertyOptional,
+  ApiExtraModels,
+} from '@nestjs/swagger';
 import { IsNotEmpty, IsString, IsNumber, IsOptional } from 'class-validator';
+import { Type } from 'class-transformer';
 
+/**
+ * 댓글 생성 DTO
+ */
 export class CreateCommentDto {
-  @ApiProperty({ description: '댓글 내용', example: '정말 유익한 요약이네요!' })
+  @ApiProperty({
+    description: '댓글 내용',
+    example: '정말 유익한 요약이네요!',
+  })
   @IsString()
   @IsNotEmpty()
   comment_text!: string;
 
-  @ApiProperty({ description: '부모 댓글 ID', example: 0, required: false })
+  @ApiPropertyOptional({
+    description: '부모 댓글 ID (대댓글 작성 시 사용)',
+    example: null,
+  })
   @IsOptional()
+  @Type(() => Number)
   @IsNumber()
   comment_parent_id?: number;
 }
 
+/**
+ * 댓글 수정 DTO
+ */
 export class UpdateCommentDto {
-  @ApiProperty({ description: '수정할 댓글 내용', example: '수정된 댓글 내용' })
+  @ApiProperty({
+    description: '수정할 댓글 내용',
+    example: '수정된 댓글입니다.',
+  })
   @IsString()
   @IsNotEmpty()
   comment_text!: string;
 }
 
-export class DeleteCommentDto {
-  @ApiProperty({ description: '댓글 ID', example: 1 })
-  @IsNumber()
-  comment_id!: number;
+/**
+ * 사용자 정보 DTO (user_nick만 노출)
+ */
+export class UserInfoDto {
+  @ApiProperty({
+    description: '사용자 닉네임',
+    example: 'yoyakswuni',
+  })
+  user_nick!: string;
 }
 
-export class GetCommentsBySummaryDto {
+/**
+ * 댓글 응답 DTO (재귀 구조 포함)
+ */
+@ApiExtraModels(CommentResponseDto)
+export class CommentResponseDto {
+  @ApiProperty({ description: '댓글 ID', example: 1 })
+  comment_id!: number;
+
+  @ApiProperty({
+    description: '댓글 내용',
+    example: '정말 유익한 요약이네요!',
+  })
+  comment_text!: string;
+
+  @ApiPropertyOptional({
+    description: '부모 댓글 ID',
+    example: null,
+  })
+  comment_parent_id?: number;
+
+  @ApiProperty({ description: '작성자 ID', example: 9 })
+  user_id!: number;
+
   @ApiProperty({ description: 'Summary ID', example: 1 })
-  @IsNumber()
   summary_id!: number;
+
+  @ApiProperty({
+    description: '댓글 생성 시간',
+    example: '2025-08-07T18:17:06.000Z',
+  })
+  created_at!: Date;
+
+  @ApiProperty({
+    description: '댓글 수정 시간',
+    example: '2025-08-07T18:17:06.000Z',
+  })
+  updated_at!: Date;
+
+  @ApiProperty({
+    description: '작성자 정보',
+    type: () => UserInfoDto,
+  })
+  user!: UserInfoDto;
+
+  @ApiProperty({
+    description: '대댓글 리스트',
+    type: () => [CommentResponseDto],
+    example: [],
+  })
+  @Type(() => CommentResponseDto)
+  replies!: CommentResponseDto[];
 }

--- a/src/layer/dtos/login.dto.ts
+++ b/src/layer/dtos/login.dto.ts
@@ -4,14 +4,14 @@ import { ApiProperty } from '@nestjs/swagger';
 export class LoginDto {
   @ApiProperty({
     description: '사용자의 이메일 주소',
-    example: 'user@example.com',
+    example: 'yoyak.lib@gmail.com',
   })
   @IsEmail()
   user_email!: string;
 
   @ApiProperty({
     description: '사용자의 비밀번호 (최소 6자 이상)',
-    example: 'password123',
+    example: 'yoyak123!',
     minLength: 6,
   })
   @IsString()


### PR DESCRIPTION
- 댓글 생성/수정/삭제/조회 로직 전체 개선
- user_id를 service 레벨에서 주입하도록 구조 변경 → 보안성 강화
- 댓글 생성 시 부모 댓글 유효성 검사 로직 추가
- 댓글 응답 DTO에 user 정보와 replies 포함되도록 수정
- Swagger 예제 응답값 실제 데이터 형태로 상세화 (예: 대댓글 포함 구조 등)
- comment_parent_id 값이 0일 경우 null로 처리되도록 예외처리 추가

<img width="688" height="503" alt="image" src="https://github.com/user-attachments/assets/7b0cd269-f1cc-4f22-8258-c4fc33050553" />
